### PR TITLE
Replace str.translate/str.maketrans with str.replace

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -175,11 +175,7 @@ class GUI:
                 Gtk.main_iteration_do(False)
 
             line = io.readline()
-            try:
-                print(line.translate(None, '\n'))
-            except:
-                char_map = str.maketrans('', '', '\n')
-                print(line.translate(char_map))
+            print(line.replace('\n', ''))
 
             return True
 

--- a/games_nebula.py
+++ b/games_nebula.py
@@ -2161,11 +2161,7 @@ class GUI:
             )
 
         for output in self.monitors_list:
-            try:
-                self.combobox_monitor.append_text(output.translate(None, '\n'))
-            except:
-                char_map = str.maketrans('', '', '\n')
-                self.combobox_monitor.append_text(output.translate(char_map))
+            self.combobox_monitor.append_text(output.replace('\n', ''))
 
         self.combobox_monitor.set_active(self.monitor)
 
@@ -5503,11 +5499,7 @@ class GUI:
         line = io.readline()
 
         if (process_name != 'check_for_new_games' ) and (process_name != 'update_goglib'):
-            try:
-                print(line.translate(None, '\n'))
-            except:
-                char_map = str.maketrans('', '', '\n')
-                print(line.translate(char_map))
+            print(line.replace('\n', ''))
 
         if self.goglib_page_exists():
             self.progressbar_goglib.pulse()
@@ -5519,17 +5511,8 @@ class GUI:
             if '%' in line:
                 mb_downloaded = line.split('@')[0].split(' ')[-2]
                 speed = line.split('@')[1].split(' ')[1]
-                try:
-                    eta = line.split('@')[1].split(' ')[3].translate(None, '\n')
-                except:
-                    char_map = str.maketrans('', '', '\n')
-                    eta = line.split('@')[1].split(' ')[3].translate(char_map)
-
-                try:
-                    percentage = line.split('%', 1)[0].translate(None, ' %\n')
-                except:
-                    char_map = str.maketrans('', '', '%\n')
-                    percentage = line.split('%', 1)[0].translate(char_map)
+                eta = line.split('@')[1].split(' ')[3].replace('\n', '')
+                percentage = line.split('%', 1)[0].replace(' ', '').replace('%', '').replace('\n', '')
 
                 for progress_bar in queue_progress_bars_list:
                     if progress_bar.get_name() == goglib_installation_queue[0]:
@@ -5575,11 +5558,7 @@ class GUI:
 
         if process_name == 'check_for_new_games':
             if '\n' in line:
-                try:
-                    game_name = line.split(' ')[0].translate(None, '\n')
-                except:
-                    char_map = str.maketrans('', '', '\n')
-                    game_name = line.split(' ')[0].translate(char_map)
+                game_name = line.split(' ')[0].replace('\n', '')
                 if '\x1b[32m' in game_name:
                     game_name = game_name.split('\x1b[32m')[1]
                 if  game_name not in self.goglib_games_list:

--- a/launcher_dosbox.py
+++ b/launcher_dosbox.py
@@ -292,12 +292,7 @@ class GUI:
         self.combobox_monitor = Gtk.ComboBoxText()
 
         for output in self.monitors_list:
-
-            try:
-                self.combobox_monitor.append_text(output.translate(None, '\n'))
-            except:
-                char_map = str.maketrans('', '', '\n')
-                self.combobox_monitor.append_text(output.translate(char_map))
+            self.combobox_monitor.append_text(output.replace('\n', ''))
 
         self.combobox_monitor.set_active(self.monitor)
 

--- a/launcher_native.py
+++ b/launcher_native.py
@@ -186,12 +186,7 @@ class GUI:
         self.combobox_monitor = Gtk.ComboBoxText()
 
         for output in self.monitors_list:
-
-            try:
-                self.combobox_monitor.append_text(output.translate(None, '\n'))
-            except:
-                char_map = str.maketrans('', '', '\n')
-                self.combobox_monitor.append_text(output.translate(char_map))
+            self.combobox_monitor.append_text(output.replace('\n', ''))
 
         self.combobox_monitor.set_active(self.monitor)
 

--- a/launcher_scummvm.py
+++ b/launcher_scummvm.py
@@ -342,12 +342,7 @@ class GUI:
         self.combobox_monitor = Gtk.ComboBoxText()
 
         for output in self.monitors_list:
-
-            try:
-                self.combobox_monitor.append_text(output.translate(None, '\n'))
-            except:
-                char_map = str.maketrans('', '', '\n')
-                self.combobox_monitor.append_text(output.translate(char_map))
+            self.combobox_monitor.append_text(output.replace('\n', ''))
 
         self.combobox_monitor.set_active(self.monitor)
 

--- a/launcher_wine.py
+++ b/launcher_wine.py
@@ -556,12 +556,7 @@ class GUI:
         self.combobox_monitor = Gtk.ComboBoxText()
 
         for output in self.monitors_list:
-
-            try:
-                self.combobox_monitor.append_text(output.translate(None, '\n'))
-            except:
-                char_map = str.maketrans('', '', '\n')
-                self.combobox_monitor.append_text(output.translate(char_map))
+            self.combobox_monitor.append_text(output.replace('\n', ''))
 
         self.combobox_monitor.set_active(self.monitor)
 
@@ -887,13 +882,7 @@ class GUI:
                 command_list = line.split(' ')
 
         del command_list[0:3]
-        exe_path = ' '.join(command_list)
-
-        try:
-            exe_path = exe_path.translate(None, '"\n')
-        except:
-            char_map = str.maketrans('', '', '"\n')
-            exe_path = exe_path.translate(char_map)
+        exe_path = ' '.join(command_list).replace('\n', '').replace('"', '')
 
         return exe_path
 

--- a/modules/goglib_get_data.py
+++ b/modules/goglib_get_data.py
@@ -14,23 +14,11 @@ def games_info(data_dir):
     with open(games_list, 'r') as in_file:
         for line in in_file:
             if 'gamename: ' in line:
-                try:
-                    list_names.append(line.split('name: ',1)[1].translate(None, '\n'))
-                except:
-                    char_map = str.maketrans('', '', '\n')
-                    list_names.append(line.split('name: ',1)[1].translate(char_map))
+                list_names.append(line.split('name: ',1)[1].replace('\n', ''))
             if 'title: ' in line:
-                try:
-                    list_titles.append(line.split('title: ',1)[1].translate(None, '\n'))
-                except:
-                    char_map = str.maketrans('', '', '\n')
-                    list_titles.append(line.split('title: ',1)[1].translate(char_map))
+                list_titles.append(line.split('title: ',1)[1].replace('\n', ''))
             if 'icon: ' in line:
-                try:
-                    list_icons.append(line.split('icon: ',1)[1].translate(None, '\n'))
-                except:
-                    char_map = str.maketrans('', '', '\n')
-                    list_icons.append(line.split('icon: ',1)[1].translate(char_map))
+                list_icons.append(line.split('icon: ',1)[1].replace('\n', ''))
     in_file.close()
 
     number_of_games = len(list_names)

--- a/modules/mylib_create_banner.py
+++ b/modules/mylib_create_banner.py
@@ -22,13 +22,7 @@ def mylib_create_banner(game_name):
 
     script_file = open(mylib_setup_script_path, 'r')
     file_content = script_file.readlines()
-    raw_game_title = file_content[-1]
-
-    try:
-        raw_game_title = raw_game_title.translate(None, '#\n')
-    except:
-        char_map = str.maketrans('', '', '#\n')
-        raw_game_title = raw_game_title.translate(char_map)
+    raw_game_title = file_content[-1].replace('#', '').replace('\n', '')
 
     if sys.version_info[0] == 2:
         game_title = raw_game_title.decode('utf-8')

--- a/modules/mylib_get_data.py
+++ b/modules/mylib_get_data.py
@@ -1,7 +1,7 @@
 import os, sys
-from os import listdir
 
 nebula_dir = sys.path[0]
+
 
 def games_info(data_dir):
 
@@ -29,7 +29,8 @@ def games_info(data_dir):
 
     number_of_games = len(list_names)
 
-    return (number_of_games, list_names, list_titles)
+    return number_of_games, list_names, list_titles
+
 
 def get_info(games_list, mylib_dir):
 
@@ -45,12 +46,7 @@ def get_info(games_list, mylib_dir):
             data = setup_file.readlines()
             setup_file.close()
 
-            try:
-                title = data[-1].translate(None, '#\n')
-            except:
-                char_map = str.maketrans('', '', '#\n')
-                title = data[-1].translate(char_map)
-
+            title = data[-1].replace('#', '').replace('\n', '')
             dict_name2title[game_name] = title
 
     return dict_name2title


### PR DESCRIPTION
The original code reuses `try`/`except` blocks for optimistically applying `translate` to strings in order to do what appears to be character removal:

```python
try:
    print(line.translate(None, '\n'))		
except:		
    char_map = str.maketrans('', '', '\n')		
    print(line.translate(char_map))
```

This code prevented Games Nebula version 20180222 from starting on Python 2.7, Python 3.5 and Python 3.6 on my machine (system Python on Ubuntu 17.10 as well as custom Python on Anaconda 5.1).

This merge requests replaces all `translate`/`maketrans` blocks with calls to `replace`, e.g.

```python
print(line.replace('\n', ''))
```

for the above example. [This SO answer](https://stackoverflow.com/a/27086669/195651) suggests that chaining multiple `replace` calls in order to remove a set of characters is not an actual performance hit, so I added this in places where more than one character needed to be stripped.