### PR TITLE
Support missing wine/scummvm at system

### DIFF
--- a/games_nebula.py
+++ b/games_nebula.py
@@ -3742,10 +3742,12 @@ class GUI:
 
         path = self.filechooserbutton_wine.get_filename()
         full_list = os.listdir(path)
-
-        for o in full_list:
-            if os.path.isdir(path + '/' + o):
-                ver_list.append(o)
+        try:
+            for o in full_list:
+                if os.path.isdir(path + '/' + o):
+                    ver_list.append(o)
+        except TypeError:
+            pass
 
         ver_list = sorted(ver_list)
 
@@ -3763,9 +3765,12 @@ class GUI:
         path = self.filechooserbutton_dosbox.get_filename()
         full_list = os.listdir(path)
 
-        for o in full_list:
-            if os.path.isdir(path + '/' + o):
-                ver_list.append(o)
+        try:
+            for o in full_list:
+                if os.path.isdir(path + '/' + o):
+                    ver_list.append(o)
+        except TypeError:
+            pass
 
         ver_list = sorted(ver_list)
 
@@ -3781,9 +3786,12 @@ class GUI:
         path = self.filechooserbutton_scummvm.get_filename()
         full_list = os.listdir(path)
 
-        for o in full_list:
-            if os.path.isdir(path + '/' + o):
-                ver_list.append(o)
+        try:
+            for o in full_list:
+                if os.path.isdir(path + '/' + o):
+                    ver_list.append(o)
+        except TypeError:
+            pass
 
         ver_list = sorted(ver_list)
 


### PR DESCRIPTION
Allows the app to work even if the user doesn't have wine or scummvm at their system.

Running games_nebula without them, gives you a weird error trying to fill information at UI from missing data.

> Traceback (most recent call last):
>   File "./games_nebula.py", line 6877, in <module>
>     sys.exit(main())
>   File "./games_nebula.py", line 6873, in main
>     app = GUI()
>   File "./games_nebula.py", line 138, in __init__
>     self.create_main_window()
>   File "./games_nebula.py", line 342, in create_main_window
>     self.create_settings_tab()
>   File "./games_nebula.py", line 2416, in create_settings_tab
>     self.populate_scummvm_version_combobox()
>   File "./games_nebula.py", line 3790, in populate_scummvm_version_combobox
>     if os.path.isdir(path + '/' + o):
> TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'

I know this is a very bad fix, but it's the simplest solution... otherwise it may require lot of modifications.

